### PR TITLE
Add database test

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,12 @@ The exercises are split into three notebooks:
   - Create foreign key to primary key relationships between tables
   - Write queries that gather data from multiple tables
   - Use a variety of join types for different scenarios
+
+## Running Tests
+
+Install the dependencies from `requirements.txt` and execute the test suite using `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ jupysql
 duckdb-engine
 pip
 ipykernel
+pytest

--- a/tests/test_cities_db.py
+++ b/tests/test_cities_db.py
@@ -1,0 +1,12 @@
+import pathlib
+import duckdb
+
+DB_PATH = pathlib.Path(__file__).resolve().parent.parent / 'cities.ddb'
+
+
+def test_cities_table_exists_and_has_rows():
+    con = duckdb.connect(str(DB_PATH))
+    tables = {row[0] for row in con.execute("PRAGMA show_tables").fetchall()}
+    assert 'cities' in tables
+    count = con.execute("SELECT COUNT(*) FROM cities").fetchone()[0]
+    assert count > 0


### PR DESCRIPTION
## Summary
- add pytest dependency
- document running tests
- add database test verifying `cities` table exists with rows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'duckdb')*

------
https://chatgpt.com/codex/tasks/task_e_683f7994653083279192ed5a6a621be9